### PR TITLE
Uppercased letters in the home menu

### DIFF
--- a/snippets/header-drawer.liquid
+++ b/snippets/header-drawer.liquid
@@ -29,7 +29,7 @@
                         id="HeaderDrawer-{{ link.handle }}"
                         class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.child_active %} menu-drawer__menu-item--active{% endif %}"
                       >
-                        {{ link.title | escape }}
+                        {{ link.title | upcase | escape }}
                         {% render 'icon-arrow' %}
                         {% render 'icon-caret' %}
                       </summary>
@@ -116,7 +116,7 @@
                         aria-current="page"
                       {% endif %}
                     >
-                      {{ link.title | escape }}
+                      {{ link.title | upcase | escape }}
                     </a>
                   {%- endif -%}
                 </li>

--- a/snippets/header-mega-menu.liquid
+++ b/snippets/header-mega-menu.liquid
@@ -21,7 +21,7 @@
                     class="header__active-menu-item"
                   {% endif %}
                 >
-                  {{- link.title | escape -}}
+                  {{- link.title | upcase | escape -}}
                 </span>
                 {% render 'icon-caret' %}
               </summary>
@@ -84,7 +84,7 @@
                 class="header__active-menu-item"
               {% endif %}
             >
-              {{- link.title | escape -}}
+              {{- link.title | upcase | escape -}}
             </span>
           </a>
         {%- endif -%}


### PR DESCRIPTION
### Before
Desktop:
![image](https://github.com/CocoaWebStudio/dawn-Napo/assets/76742898/2f709972-9a36-4258-9684-58ce88938b62)

### After
Desktop:
![image](https://github.com/CocoaWebStudio/dawn-Napo/assets/76742898/5c50d40b-6c7d-484f-9b51-09fe78c847ff)
Mobile:
![image](https://github.com/CocoaWebStudio/dawn-Napo/assets/76742898/250331a1-3164-408d-b032-8a7345e3096f)
